### PR TITLE
Solicitar varias etiquetas apenas uma requisição

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tmp/
 vendor/
 /.idea
 /nbproject/private/

--- a/src/PhpSigep/Model/SolicitaEtiquetas.php
+++ b/src/PhpSigep/Model/SolicitaEtiquetas.php
@@ -18,6 +18,13 @@ class SolicitaEtiquetas extends AbstractModel
      */
     protected $qtdEtiquetas;
     /**
+     * Padrão true
+     * Quando true fará para cada etiqueta solicitada uma requisição para os correios com base no valor de $qtdEtiquetas
+     * Quando false incorporará ao XML de solicitação de etiqueta e portanto apenas uma requisição para os correios.
+     * @var boolean
+     */
+    protected $modoMultiplasRequisicoes = true;
+    /**
      * Opcional.
      * Quando não informado será usado o valor retornado pelo método {@link \PhpSigep\Bootstrap::getConfig() }
      * @var AccessData
@@ -64,6 +71,28 @@ class SolicitaEtiquetas extends AbstractModel
     public function getServicoDePostagem()
     {
         return $this->servicoDePostagem;
+    }
+    
+    /**
+     * Atribui para modoMultiplasRequisicoes true
+     */
+    public function setModoMultiplasRequisicoes(){
+        $this->modoMultiplasRequisicoes = true;
+    }
+    
+    /**
+     * Atribui para modoMultiplasRequisicoes false
+     */
+    public function setModoUmaRequisicao(){
+        $this->modoMultiplasRequisicoes = false;
+    }
+    
+    /**
+     * 
+     * @return boolean
+     */
+    public function isModoMultiplasRequisicoes(){
+        return $this->modoMultiplasRequisicoes;
     }
 
     /**

--- a/src/PhpSigep/Services/Real/SolicitaEtiquetas.php
+++ b/src/PhpSigep/Services/Real/SolicitaEtiquetas.php
@@ -12,6 +12,81 @@ use PhpSigep\Services\Result;
 class SolicitaEtiquetas implements RealServiceInterface
 {
 
+    private function validAfterRequest($request){
+        if (class_exists('\StaLib_Logger')) {
+            \StaLib_Logger::log('Retorno SIGEP solicitar etiquetas: ' . print_r($request, true));
+        }
+        
+        if ($request && is_object($request) && isset($request->return) && !($request instanceof \SoapFault)) {
+            return true;
+        } else {
+            if ($request instanceof \SoapFault) {
+                throw $request;
+            }
+            throw new \Exception('Não foi possível obter as etiquetas solicitadas. Retorno: "' . $request . '"');
+        }
+    }
+    
+    /**
+     * Busca numero da etiqueta em uma unica requisição assim garantindo que os numeros das etiquetas não tenham intervalos
+     * @param array $soapArgs
+     * @param AbstractModel $params
+     * @return Etiqueta[]
+     */
+    private function findOneRequest($soapArgs, $params) {
+
+        $etiquetasReservadas = array();
+        
+        //Atribui a quantidade de etiquetas desejadas
+        $soapArgs['qtdEtiquetas'] = $params->getQtdEtiquetas();
+
+        $request = SoapClientFactory::getSoapClient()->solicitaEtiquetas($soapArgs);
+
+        if($this->validAfterRequest($request)){
+
+            $faixaEtiqueta = explode(',', $request->return);
+            
+            $numerosEtiqueta = $this->createNumberEtiquetasByRange($faixaEtiqueta[0], $faixaEtiqueta[1]);
+
+            foreach ($numerosEtiqueta as $numeroEtiqueta){
+                $etiqueta = new Etiqueta();
+                $etiqueta->setEtiquetaSemDv($numeroEtiqueta);
+                $etiquetasReservadas[] = $etiqueta;
+            }
+
+        }
+        
+        return $etiquetasReservadas;
+        
+    }
+    
+    /**
+     * Busca numero da etiqueta em uma unica requisição assim garantindo que os numeros das etiquetas não tenham intervalos
+     * @param array $soapArgs
+     * @param AbstractModel $params
+     * @return Etiqueta[]
+     */
+    private function findMultRequest($soapArgs, $params) {
+        
+        $etiquetasReservadas = array();
+        
+        for ($i = 0; $i < $params->getQtdEtiquetas(); $i++) {
+            
+            $request = SoapClientFactory::getSoapClient()->solicitaEtiquetas($soapArgs);
+            
+            if($this->validAfterRequest($request)){
+                $request = explode(',', $request->return);
+
+                $etiqueta = new Etiqueta();
+                $etiqueta->setEtiquetaSemDv($request[0]);
+                $etiquetasReservadas[] = $etiqueta;
+            }
+        }
+        
+        return $etiquetasReservadas;
+        
+    }
+
     /**
      * @param \PhpSigep\Model\AbstractModel|\PhpSigep\Model\SolicitaEtiquetas $params
      *
@@ -42,27 +117,13 @@ class SolicitaEtiquetas implements RealServiceInterface
             ) {
                 throw new Exception('Para usar este serviço você precisa setar o nome de usuário e senha.');
             }
-            
-            $etiquetasReservadas = array();
-            for ($i = 0; $i < $params->getQtdEtiquetas(); $i++) {
-                $r = SoapClientFactory::getSoapClient()->solicitaEtiquetas($soapArgs);
-                if (class_exists('\StaLib_Logger')) {
-                    \StaLib_Logger::log('Retorno SIGEP solicitar etiquetas: ' . print_r($r, true));
-                }
-                if ($r && is_object($r) && isset($r->return) && !($r instanceof \SoapFault)) {
-                    $r = explode(',', $r->return);
-    //				$etiquetasReservadas[] = str_replace(' ', '', $r[0]);
-                    $etiqueta = new Etiqueta();
-                    $etiqueta->setEtiquetaSemDv($r[0]);
-                    $etiquetasReservadas[] = $etiqueta;
-                } else {
-                    if ($r instanceof \SoapFault) {
-                        throw $r;
-                    }
-                    throw new \Exception('Não foi possível obter as etiquetas solicitadas. Retorno: "' . $r . '"');
-                }
+
+            if($params->isModoMultiplasRequisicoes()){
+                $result->setResult($this->findMultRequest($soapArgs, $params));
+            }else{
+                $result->setResult($this->findOneRequest($soapArgs, $params));
             }
-            $result->setResult($etiquetasReservadas);
+            
         } catch (\Exception $e) {
             if ($e instanceof \SoapFault) {
                 $result->setIsSoapFault(true);
@@ -76,4 +137,27 @@ class SolicitaEtiquetas implements RealServiceInterface
 
         return $result;
     }
+    
+    public function createNumberEtiquetasByRange($startingEtiqueta, $finalEtiqueta){
+        
+        $prefix = \substr($startingEtiqueta, 0, 2);
+        $sufix  = \substr($startingEtiqueta, 11);
+                
+        $startingNumber = $this->getNumbersEtiqueta($startingEtiqueta);
+        $finalNumber = $this->getNumbersEtiqueta($finalEtiqueta);
+        
+        $numbersEtiquetas = array();
+        
+        for ($i = $startingNumber; $i <= $finalNumber; $i++){
+            $numbersEtiquetas[] = $prefix.$i.' '.$sufix;
+        }
+        
+        return $numbersEtiquetas;
+        
+    }
+    
+    private function getNumbersEtiqueta($etiqueta){
+        return preg_replace('/\D/', '', $etiqueta);
+    }
+    
 }

--- a/tests/Services/SolicitaEtiquetasTest.php
+++ b/tests/Services/SolicitaEtiquetasTest.php
@@ -5,7 +5,7 @@ class SolicitaEtiquetasTest extends TestCase
 
 	public function testEtiquetas()
 	{
-		$etiquetas = new PhpSigep\Services\SolicitaEtiquetas();
+		$etiquetas = new PhpSigep\Services\Real\SolicitaEtiquetas();
 		$params    = new \PhpSigep\Model\SolicitaEtiquetas(array(
 			'qtdEtiquetas'      => 1,
 			'servicoDePostagem' => new PhpSigep\Model\ServicoDePostagem(PhpSigep\Model\ServicoDePostagem::SERVICE_E_SEDEX_STANDARD),

--- a/tests/Services/SolicitaEtiquetasTest.php
+++ b/tests/Services/SolicitaEtiquetasTest.php
@@ -3,20 +3,119 @@
 class SolicitaEtiquetasTest extends TestCase
 {
 
-	public function testEtiquetas()
-	{
-		$etiquetas = new PhpSigep\Services\Real\SolicitaEtiquetas();
-		$params    = new \PhpSigep\Model\SolicitaEtiquetas(array(
-			'qtdEtiquetas'      => 1,
-			'servicoDePostagem' => new PhpSigep\Model\ServicoDePostagem(PhpSigep\Model\ServicoDePostagem::SERVICE_E_SEDEX_STANDARD),
-			'accessData'        => new PhpSigep\Model\AccessData(array(
-				'cnpjEmpresa' => '16.646.849/0001-77',
-				'usuario'     => 'usuario',
-				'senha'       => 'senha',
-			))
-		));
+    public function setUp() {
+        
+        $config = new \PhpSigep\Config();
+        
+        $config->setAccessData(new \PhpSigep\Model\AccessDataHomologacao());
+        
+        $config->setEnv(\PhpSigep\Config::ENV_PRODUCTION);
+        
+        
+        $config->setCacheOptions(array(
+           'storageOptions' => array(
+                'enabled' => false,
+                'ttl' => 10,
+                'cacheDir' => sys_get_temp_dir()
+            )
+        ));
+        
+        \PhpSigep\Bootstrap::start($config);
+        
+    }
+    
+    public function Etiquetas(){
+        $etiquetas = new PhpSigep\Services\Real\SolicitaEtiquetas();
+        $params    = new \PhpSigep\Model\SolicitaEtiquetas(array(
+                'qtdEtiquetas'      => 1,
+                'servicoDePostagem' => new PhpSigep\Model\ServicoDePostagem(PhpSigep\Model\ServicoDePostagem::SERVICE_E_SEDEX_STANDARD),
+                'accessData'        => new PhpSigep\Model\AccessData(array(
+                        'cnpjEmpresa' => '16.646.849/0001-77',
+                        'usuario'     => 'usuario',
+                        'senha'       => 'senha',
+                ))
+        ));
 
-		$this->assertCount(1, $etiquetas->execute($params), "Deve ter reservado uma etiqueta");
-	}
+        $this->assertCount(1, $etiquetas->execute($params), "Deve ter reservado uma etiqueta");
+    }
+    
+    public function testCreateEtiquetasByRange() {
+
+        $service = new \PhpSigep\Services\Real\SolicitaEtiquetas();
+        
+        $primeiraEtiqueta = 'EC31081466 BR';
+        $ultimaEtiqueta = 'EC31081471 BR';
+        $retornoEsperado = array('EC31081466 BR', 'EC31081467 BR', 'EC31081468 BR', 'EC31081469 BR', 'EC31081470 BR', 'EC31081471 BR');
+        $numerosEtiquetas = $service->createNumberEtiquetasByRange($primeiraEtiqueta, $ultimaEtiqueta);
+
+        $this->assertEquals($retornoEsperado, $numerosEtiquetas);
+        
+        $primeiraEtiqueta = 'EC31081466 BR';
+        $ultimaEtiqueta = 'EC31081466 BR';
+        $retornoEsperado = array('EC31081466 BR');
+        $numerosEtiquetas = $service->createNumberEtiquetasByRange($primeiraEtiqueta, $ultimaEtiqueta);
+
+        $this->assertEquals($retornoEsperado, $numerosEtiquetas);
+        
+        $primeiraEtiqueta = 'EC31081466 BR';
+        $ultimaEtiqueta = 'EC31081467 BR';
+        $retornoEsperado = array('EC31081466 BR', 'EC31081467 BR');
+        $numerosEtiquetas = $service->createNumberEtiquetasByRange($primeiraEtiqueta, $ultimaEtiqueta);
+
+        $this->assertEquals($retornoEsperado, $numerosEtiquetas);
+        
+        $primeiraEtiqueta = 'EC31081466 BR';
+        $ultimaEtiqueta = 'EC31081465 BR';
+        $retornoEsperado = array();
+        $numerosEtiquetas = $service->createNumberEtiquetasByRange($primeiraEtiqueta, $ultimaEtiqueta);
+        
+        $this->assertEquals($retornoEsperado, $numerosEtiquetas);
+        
+    }
+
+    public function testSolicitarEtiquetaUmRequisicao(){
+        
+        $quantidadeEtiquetas = 10;
+        
+        $params = new \PhpSigep\Model\SolicitaEtiquetas();
+        $params->setQtdEtiquetas($quantidadeEtiquetas);
+        $params->setServicoDePostagem(\PhpSigep\Model\ServicoDePostagem::SERVICE_PAC_41068);
+        $params->setAccessData(new \PhpSigep\Model\AccessDataHomologacao());
+        $params->setModoUmaRequisicao();
+
+        $phpSigep = new PhpSigep\Services\SoapClient\Real();
+
+        $etiquetaSolicitada = $phpSigep->solicitaEtiquetas($params);
+        
+        $this->assertInstanceOf('\PhpSigep\Services\Result', $etiquetaSolicitada);
+
+        $etiquetas  = $etiquetaSolicitada->getResult();
+        
+        $this->assertCount($quantidadeEtiquetas, $etiquetas);
+        
+    }
+    
+    public function testclerSolicitarEtiquetaVariasRequisicoes(){
+        
+        $quantidadeEtiquetas = 10;
+            
+        $params = new \PhpSigep\Model\SolicitaEtiquetas();
+        $params->setQtdEtiquetas($quantidadeEtiquetas);
+        $params->setServicoDePostagem(\PhpSigep\Model\ServicoDePostagem::SERVICE_PAC_41068);
+        $params->setAccessData(new \PhpSigep\Model\AccessDataHomologacao());
+        $params->setModoMultiplasRequisicoes();
+
+        $phpSigep = new PhpSigep\Services\SoapClient\Real();
+
+        $etiquetaSolicitada = $phpSigep->solicitaEtiquetas($params);
+        
+        $this->assertInstanceOf('\PhpSigep\Services\Result', $etiquetaSolicitada);
+
+        $etiquetas  = $etiquetaSolicitada->getResult();
+        
+        $this->assertCount($quantidadeEtiquetas, $etiquetas);
+        
+    }
+        
 
 }


### PR DESCRIPTION
Para não quebrar com os projeto que já estão em produção foi criado o método setModoUmaRequisicao, mas por padrão é  setModoMultiplasRequisicoes do Model\SolicitaEtiquetas