### PR TITLE
Removendo conversão do número da nota fiscal para inteiro

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -256,7 +256,7 @@ class CartaoDePostagem2018
             $this->pdf->SetXY(5, 27);
             $this->pdf->SetFontSize(9);
             //$this->pdf->SetTextColor(51,51,51);
-            $nf = (int)$objetoPostal->getDestino()->getNumeroNotaFiscal();
+            $nf = $objetoPostal->getDestino()->getNumeroNotaFiscal();
             $str = $nf > 0 ?  'NF: '. $nf : ' ';
             $this->t(15, $str, 1, 'L',  null);
 


### PR DESCRIPTION
Removendo conversão do número da nota fiscal para inteiro pois quando o mesmo inicia com zero ao converter ele remove esse número ocasionando em problemas nos
correios pois o número da nota fiscal deve ser composto por 5 números